### PR TITLE
Throw an actual Error object instead of a string

### DIFF
--- a/platform/safari/vapi-client.js
+++ b/platform/safari/vapi-client.js
@@ -639,7 +639,7 @@ else return wo.apply(this, arguments);\
 };\
 XMLHttpRequest.prototype.open = function(m, u) {\
 if ( block(u, "xmlhttprequest") ) {\
-throw "InvalidAccessError"; return;\
+throw new Error("InvalidAccessError"); return;\
 } else {\
 xo.apply(this, arguments); return;}\
 };';


### PR DESCRIPTION
Error objects have stack properties that can be passed to error reporting tools; strings do not. Helpful for use with open source error reporting tools like Sentry.

Refs gorhill/uBlock#2415