### PR TITLE
Extension should list Raymond Hill and Ellis Tsung, not that other guy

### DIFF
--- a/platform/safari/Info.plist
+++ b/platform/safari/Info.plist
@@ -3,7 +3,7 @@
 <plist version="1.0">
 <dict>
     <key>Author</key>
-    <string>Chris Aljoudi/Raymond Hill</string>
+    <string>Raymond Hill & Ellis Tsung</string>
     <key>Builder Version</key>
     <string>534.57.2</string>
     <key>CFBundleDisplayName</key>


### PR DESCRIPTION
Why is @chrisaljoudi's name associated with this extension, and why is his name placed ahead of @gorhill's? 😦 

Chris does not deserve to be further rewarded for the dishonesty and stunts he's pulled and continues to pull. :angry: He even [dares call uBlock Origin a "personal fork of uBlock from @gorhill"](https://github.com/chrisaljoudi/ublock#about-ublock) 😡 

![ublock origin as installed](https://user-images.githubusercontent.com/5885378/31588279-8ea292fc-b1bd-11e7-802e-293619464b80.png)

The [uBlock Origin Firefox addon](https://addons.mozilla.org/en-US/firefox/addon/ublock-origin/) lists Raymond Hill. 😇 

[Chris's Firefox addon](https://addons.mozilla.org/en-US/firefox/addon/ublock/) lists himself. :smiling_imp:

The uBlock Safari extension should be "Raymond Hill/Ellis Tsung" as the named responsibles. 🤓 

For end users, especially the non-technical ones, we should provide as much clarity as possible (See also #69). 😎 